### PR TITLE
(fix) base model class string representation

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -50,7 +50,9 @@ class BaseModel():
 
     def __str__(self):
         """ Returns the string representation of the object. """
-        return "[BaseModel] (" + self.id + ") " + str(self.__dict__)
+        return "[{}] ({}) {}".format(self.__class__.__name__,
+                                     self.id,
+                                     self.to_dict())
 
     def save(self):
         """ Updates the instance update date. """


### PR DESCRIPTION
Fixed BaseModel __str__ method printing "[BaseModel] ..." no matter
if the instance comes from a subclass.